### PR TITLE
add GH CI action to build vs2022 versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,25 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        vc_arch: [32, 64]
+        vc_ver: [14.3]
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: run python build script
+      working-directory: .
+      run: python ./run.py --vc-arch ${{ matrix.vc_arch }} --vc-ver ${{ matrix.vc_ver }}
+

--- a/.github/workflows/Daily_master_snapshot_build.yml
+++ b/.github/workflows/Daily_master_snapshot_build.yml
@@ -1,0 +1,28 @@
+name: Daily Integration master-snapshot
+
+on:
+  schedule:
+    - cron: '0 23 * * *'
+
+
+jobs:
+  build:
+
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        vc_arch: [32, 64]
+        vc_ver: [14.3]
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: run python build script
+      working-directory: .
+      run: python ./run.py --type=master-snapshot --vc-arch ${{ matrix.vc_arch }} --vc-ver ${{ matrix.vc_ver }}
+

--- a/run.py
+++ b/run.py
@@ -21,9 +21,9 @@ import repo_paths
 VERSION = "89"
 MINOR_VERSION = "0"
 #TYPE = "master-snapshot"
-TYPE = "beta-rc"
+#TYPE = "beta-rc"
 #TYPE = "beta" # Never used, build Beta RC
-#TYPE = "rc"
+TYPE = "rc"
 #TYPE = "release" # Never used, build RC
 REPO = "archives"
 BETA = 1


### PR DESCRIPTION
- added --type=release as not yet committed
- could be extended to check also other VS versions on older docker images